### PR TITLE
Add helper methods to decimal and ensure scientific notation is never used

### DIFF
--- a/decimal.go
+++ b/decimal.go
@@ -7,6 +7,8 @@ import (
 	"github.com/ericlagergren/decimal"
 )
 
+var zero Decimal = Zero()
+
 type Decimal struct {
 	nat *decimal.Big
 }
@@ -358,12 +360,17 @@ func (d Decimal) MustFloat64() float64 {
 }
 
 func (d Decimal) String() string {
-	if d.native() == nil {
+	if d.native() == nil || d.Equals(zero) {
 		return "0"
 	}
-	return d.native().String()
+	return fmt.Sprintf("%f", d)
 }
 
 func (d Decimal) Bytes() []byte {
 	return []byte(d.String())
+}
+
+// Format implements the fmt.Formatter interface.
+func (d Decimal) Format(s fmt.State, c rune) {
+	d.native().Format(s, c)
 }

--- a/marshal.go
+++ b/marshal.go
@@ -2,7 +2,7 @@ package decimal
 
 import "bytes"
 
-// UnmarshalText implements the encoding.TextMarshaler interface for serialization
+// MarshalText implements the encoding.TextMarshaler interface for serialization
 func (d Decimal) MarshalText() ([]byte, error) {
 	return []byte(d.String()), nil
 }
@@ -22,7 +22,7 @@ func (d Decimal) MarshalJSON() ([]byte, error) {
 	return d.MarshalText()
 }
 
-// UnmarshalText implements the json.Unmarshaler interface for deserialization
+// UnmarshalJSON implements the json.Unmarshaler interface for deserialization
 func (d *Decimal) UnmarshalJSON(buf []byte) error {
 	return d.UnmarshalText(bytes.Trim(bytes.TrimSpace(buf), `"`))
 }

--- a/operations.go
+++ b/operations.go
@@ -198,9 +198,14 @@ func (dec Decimal) RoundToDigits(digits int) Decimal {
 	prec := dec.native().Precision()
 	scale := dec.native().Scale()
 
-	if scale > prec {
-		digits = digits - 1
-	} else if scale < prec {
+	// if we have more significant digits (prec) than
+	// digits after decimal point (scale) then we want
+	// to have the digits after decimal point
+	// set to (digits - (prec - scale))
+	// for example, 1.23 has prec=3 and scale=2
+	// we want to round it to 2 digits
+	// so we want the new scale to equal (2 - (3 - 2))=1
+	if scale < prec {
 		left := prec - scale
 		digits = digits - left
 	}

--- a/operations.go
+++ b/operations.go
@@ -159,7 +159,7 @@ func RoundToInt(a Decimal) Decimal {
 
 // Truncate truncates the instance to the specific digits
 func (dec Decimal) Truncate(digits int) Decimal {
-	parts := strings.SplitN(dec.native().String(), ".", 2)
+	parts := strings.SplitN(dec.String(), ".", 2)
 	if len(parts) <= 1 {
 		v, _ := NewFromString(parts[0])
 		dec.native().Copy(v.native())
@@ -178,4 +178,54 @@ func (dec Decimal) Truncate(digits int) Decimal {
 func Truncate(a Decimal, digits int) Decimal {
 	d := NewFromDecimal(a)
 	return d.Truncate(digits)
+}
+
+// Quantize sets dec to the number equal in value and sign to dec with the scale, digits.
+func (dec Decimal) Quantize(digits int) Decimal {
+	dec.native().Quantize(digits)
+	return Decimal{dec.native()}
+}
+
+// Quantize sets a to the number equal in value and sign to a with the scale, digits.
+// a will not be modified.
+func Quantize(a Decimal, digits int) Decimal {
+	d := NewFromDecimal(a)
+	return d.Quantize(digits)
+}
+
+// RoundToDigits rounds a to make it have as many digits if possible.
+func (dec Decimal) RoundToDigits(digits int) Decimal {
+	prec := dec.native().Precision()
+	scale := dec.native().Scale()
+
+	if scale > prec {
+		digits = digits - 1
+	} else if scale < prec {
+		left := prec - scale
+		digits = digits - left
+	}
+
+	if digits < 0 {
+		digits = 0
+	}
+
+	dec.native().Quantize(digits)
+	return Decimal{dec.native()}
+}
+
+// RoundToDigits rounds a to make it have as many digits if possible.
+// a will not be modified.
+func RoundToDigits(a Decimal, digits int) Decimal {
+	d := NewFromDecimal(a)
+	return d.RoundToDigits(digits)
+}
+
+// Precision returns precision of dec.
+func (dec Decimal) Precision() int {
+	return dec.native().Precision()
+}
+
+// Scale returns scale of dec.
+func (dec Decimal) Scale() int {
+	return dec.native().Scale()
 }

--- a/operations_test.go
+++ b/operations_test.go
@@ -172,13 +172,21 @@ func TestCeil(t *testing.T) {
 }
 
 func TestRound(t *testing.T) {
-	data := setup("6.56")
-	require.Equal(t, "6.6", decimal.Round(data.Decimals[0], 2).String())
-	data.VerifyIntegrity(t)
-
-	require.Equal(t, "6.6", data.Decimals[0].Round(2).String())
-	data.StringRepresentations[0] = "6.6"
-	data.VerifyIntegrity(t)
+	testData := []struct {
+		input    string
+		digits   int
+		expected string
+	}{
+		{input: "6.56", digits: 2, expected: "6.6"},
+		{input: "6.6", digits: 2, expected: "6.6"},
+		{input: "-5.684341886E-14", digits: 10, expected: "-0.00000000000005684341886"},
+	}
+	for i, j := range testData {
+		data := setup(j.input)
+		output := decimal.Round(data.Decimals[0], j.digits).String()
+		require.Equal(t, j.expected, output, "At %d: %s ≠ %s", i, j.input, output)
+		data.VerifyIntegrity(t)
+	}
 }
 
 func TestTruncate(t *testing.T) {
@@ -260,6 +268,7 @@ func TestQuantize(t *testing.T) {
 		{input: "6E-2", digits: 1, expected: "0.1"},
 		{input: "0.00001", digits: 1, expected: "0"},
 		{input: "123.44", digits: 1, expected: "123.4"},
+		{input: "-5.684341886E-14", digits: 10, expected: "0"},
 	}
 	for i, j := range testData {
 		data := setup(j.input)

--- a/operations_test.go
+++ b/operations_test.go
@@ -216,3 +216,86 @@ func TestRoundToInt(t *testing.T) {
 		data.VerifyIntegrity(t)
 	}
 }
+
+func TestPrecisionAndScale(t *testing.T) {
+	testData := []struct {
+		input     string
+		precision int
+		scale     int
+	}{
+		{input: "6.1", precision: 2, scale: 1},
+		{input: "1.0", precision: 2, scale: 1},
+		{input: "10", precision: 2, scale: 0},
+		{input: "1.5", precision: 2, scale: 1},
+		{input: "0.1", precision: 1, scale: 1},
+		{input: "1E-10", precision: 1, scale: 10},
+		{input: "1.0123456789E10", precision: 11, scale: 0},
+		{input: "1.0123456789E9", precision: 11, scale: 1},
+		{input: "01.0123456789E9", precision: 11, scale: 1},
+		{input: "01.012345678900E9", precision: 13, scale: 3},
+		{input: "0.00001", precision: 1, scale: 5},
+		{input: "123.45", precision: 5, scale: 2},
+	}
+	for i, j := range testData {
+		data := setup(j.input)
+		precision := data.Decimals[0].Precision()
+		scale := data.Decimals[0].Scale()
+		require.Equal(t, j.precision, precision, "Wrong precision at %d: %d ≠ %d for input %s", i, j.precision, precision, j.input)
+		require.Equal(t, j.scale, scale, "Wrong scale at %d: %d ≠ %d for input %s", i, j.scale, scale, j.input)
+		data.VerifyIntegrity(t)
+	}
+}
+
+func TestQuantize(t *testing.T) {
+	testData := []struct {
+		input    string
+		digits   int
+		expected string
+	}{
+		{input: "6.1", digits: 0, expected: "6"},
+		{input: "1.0", digits: 2, expected: "1.00"},
+		{input: "10", digits: -1, expected: "10"},
+		{input: "1.56", digits: 1, expected: "1.6"},
+		{input: "6E-2", digits: 2, expected: "0.06"},
+		{input: "6E-2", digits: 1, expected: "0.1"},
+		{input: "0.00001", digits: 1, expected: "0"},
+		{input: "123.44", digits: 1, expected: "123.4"},
+	}
+	for i, j := range testData {
+		data := setup(j.input)
+		output := decimal.Quantize(data.Decimals[0], j.digits).String()
+		require.Equal(t, j.expected, output, "At %d: %s ≠ %s", i, j.input, output)
+		data.VerifyIntegrity(t)
+	}
+}
+
+func TestRoundToDigits(t *testing.T) {
+	testData := []struct {
+		input    string
+		digits   int
+		expected string
+	}{
+		{input: "6.1", digits: 0, expected: "6"},
+		{input: "1.0", digits: 2, expected: "1.0"},
+		{input: "1.0", digits: 3, expected: "1.00"},
+		{input: "10", digits: -1, expected: "10"},
+		{input: "1.56", digits: 1, expected: "2"},
+		{input: "6E-2", digits: 2, expected: "0.1"},
+		{input: "6E-2", digits: 1, expected: "0"},
+		{input: "0.00001", digits: 1, expected: "0"},
+		{input: "123.44", digits: 1, expected: "123"},
+		{input: "123.5", digits: 1, expected: "124"},
+		{input: "6.56", digits: 2, expected: "6.6"},
+		{input: "6.5", digits: 2, expected: "6.5"},
+		{input: "123", digits: 2, expected: "123"},
+		{input: "6.2E-3", digits: 4, expected: "0.006"},
+		{input: "6.2E-3", digits: 6, expected: "0.00620"},
+		{input: "6.2E-3", digits: 3, expected: "0.01"},
+	}
+	for i, j := range testData {
+		data := setup(j.input)
+		output := decimal.RoundToDigits(data.Decimals[0], j.digits).String()
+		require.Equal(t, j.expected, output, "At %d: %s ≠ %s", i, j.input, output)
+		data.VerifyIntegrity(t)
+	}
+}

--- a/operations_test.go
+++ b/operations_test.go
@@ -184,7 +184,7 @@ func TestRound(t *testing.T) {
 	for i, j := range testData {
 		data := setup(j.input)
 		output := decimal.Round(data.Decimals[0], j.digits).String()
-		require.Equal(t, j.expected, output, "At %d: %s ≠ %s", i, j.input, output)
+		require.Equal(t, j.expected, output, "At %d: %s ≠ %s", i, j.expected, output)
 		data.VerifyIntegrity(t)
 	}
 }
@@ -273,7 +273,7 @@ func TestQuantize(t *testing.T) {
 	for i, j := range testData {
 		data := setup(j.input)
 		output := decimal.Quantize(data.Decimals[0], j.digits).String()
-		require.Equal(t, j.expected, output, "At %d: %s ≠ %s", i, j.input, output)
+		require.Equal(t, j.expected, output, "At %d: %s ≠ %s", i, j.expected, output)
 		data.VerifyIntegrity(t)
 	}
 }
@@ -289,22 +289,28 @@ func TestRoundToDigits(t *testing.T) {
 		{input: "1.0", digits: 3, expected: "1.00"},
 		{input: "10", digits: -1, expected: "10"},
 		{input: "1.56", digits: 1, expected: "2"},
-		{input: "6E-2", digits: 2, expected: "0.1"},
-		{input: "6E-2", digits: 1, expected: "0"},
+		{input: "6E-2", digits: 2, expected: "0.06"},
+		{input: "6E-2", digits: 1, expected: "0.1"},
 		{input: "0.00001", digits: 1, expected: "0"},
+		{input: "0.00001", digits: 5, expected: "0.00001"},
 		{input: "123.44", digits: 1, expected: "123"},
 		{input: "123.5", digits: 1, expected: "124"},
 		{input: "6.56", digits: 2, expected: "6.6"},
 		{input: "6.5", digits: 2, expected: "6.5"},
 		{input: "123", digits: 2, expected: "123"},
-		{input: "6.2E-3", digits: 4, expected: "0.006"},
-		{input: "6.2E-3", digits: 6, expected: "0.00620"},
-		{input: "6.2E-3", digits: 3, expected: "0.01"},
+		{input: "6.2E-3", digits: 5, expected: "0.00620"},
+		{input: "6.2E-3", digits: 4, expected: "0.0062"},
+		{input: "6.2E-3", digits: 3, expected: "0.006"},
+		{input: "6.2E-3", digits: 2, expected: "0.01"},
+		{input: "6.2E-3", digits: 1, expected: "0"},
+		{input: "0.1", digits: 3, expected: "0.100"},
+		{input: "0.1", digits: 2, expected: "0.10"},
+		{input: "0.1", digits: 1, expected: "0.1"},
 	}
 	for i, j := range testData {
 		data := setup(j.input)
 		output := decimal.RoundToDigits(data.Decimals[0], j.digits).String()
-		require.Equal(t, j.expected, output, "At %d: %s ≠ %s", i, j.input, output)
+		require.Equal(t, j.expected, output, "At %d: %s ≠ %s", i, j.expected, output)
 		data.VerifyIntegrity(t)
 	}
 }


### PR DESCRIPTION
## Problem

The underlying decimal package we use has nice helper methods that could be useful for us. Especially `Quantize` method which does what we usually expect `Round` to do.

The difference between the two methods is that `Round` works on the precision while `Quantize` works on the scale.
The precision being the significant digits while the scale is the number of digits after the decimal point.

To better demonstrate this:
`Round(-5.684341886E-14, 10)` -> `-5.684341886E-14`
`Quantize(-5.684341886E-14, 10)` -> `0`